### PR TITLE
Updating runtime to node20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # openshift-tools-installer Changelog
+## v1.13
+- Update action to run on Node20. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
 
 ## v1.12
 - Update action/core dependency to 1.10.0

--- a/action.yml
+++ b/action.yml
@@ -82,5 +82,5 @@ outputs:
   installed:
     description: 'JSON object describing the versions that were installed.'
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
### Description
Updating runtime to node20.

### Related Issue(s)
https://github.com/redhat-actions/openshift-tools-installer/issues/103
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/


### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [x] This change is not user-facing
- [ ] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made
updated action runner to node20.
